### PR TITLE
Fix for gc arc

### DIFF
--- a/nico.nim
+++ b/nico.nim
@@ -2201,12 +2201,11 @@ proc setSpritesheet*(index: int) =
     raise newException(Exception, "No spritesheet loaded: " & $index)
   spritesheet = spritesheets[index]
 
-{.push sinkInference: off.}
 proc loadSpriteSheet*(index: int, filename: string, tileWidth,tileHeight: Pint = 8) =
   if index < 0 or index >= spritesheets.len:
     raise newException(Exception, "Invalid spritesheet " & $index)
   let shouldReplace = spritesheet == spritesheets[index]
-  backend.loadSurfaceIndexed(joinPath(assetPath,filename)) do(surface: Surface):
+  backend.loadSurfaceIndexed(joinPath(assetPath,filename)) do(surface: Surface) {.nosinks.}:
     echo "loaded spritesheet: ", filename, " ", surface.w, "x", surface.h, " tile:", tileWidth, "x", tileHeight
     spritesheets[index] = surface
     spritesheets[index].tw = tileWidth
@@ -2214,7 +2213,6 @@ proc loadSpriteSheet*(index: int, filename: string, tileWidth,tileHeight: Pint =
     spritesheets[index].filename = filename
     if shouldReplace:
       setSpritesheet(index)
-{.pop.}
 
 proc spriteSize*(): (int,int) =
   return (spritesheet.tw, spritesheet.th)

--- a/nico.nim
+++ b/nico.nim
@@ -2201,6 +2201,7 @@ proc setSpritesheet*(index: int) =
     raise newException(Exception, "No spritesheet loaded: " & $index)
   spritesheet = spritesheets[index]
 
+{.push sinkInference: off.}
 proc loadSpriteSheet*(index: int, filename: string, tileWidth,tileHeight: Pint = 8) =
   if index < 0 or index >= spritesheets.len:
     raise newException(Exception, "Invalid spritesheet " & $index)
@@ -2213,6 +2214,7 @@ proc loadSpriteSheet*(index: int, filename: string, tileWidth,tileHeight: Pint =
     spritesheets[index].filename = filename
     if shouldReplace:
       setSpritesheet(index)
+{.pop.}
 
 proc spriteSize*(): (int,int) =
   return (spritesheet.tw, spritesheet.th)


### PR DESCRIPTION
without it the error, when building exampleApp is:

```
nico.nim(2153, 21) Error: type mismatch: got <string, proc (surface: sink Surface){.closure, locks: 0.}>
but expected one of: 
proc loadSurfaceIndexed(filename: string; callback: proc (surface: common.Surface))
  first type mismatch at position: 2
  required type for callback: proc (surface: Surface){.closure.}
  but expression 'proc (surface: Surface) =
  echo ["loaded spritesheet: ", filename, " ", surface.w, "x", surface.h, " tile:",
       tileWidth, "x", tileHeight]
  spritesheets[index] = surface
  spritesheets[index].tw = tileWidth
  spritesheets[index].th = tileHeight
  spritesheets[index].filename = filename
  if shouldReplace:
    setSpritesheet(index)' is of type: proc (surface: sink Surface){.closure, locks: 0.}

expression: loadSurfaceIndexed(joinPath(assetPath, filename), proc (surface: Surface) =
  echo ["loaded spritesheet: ", filename, " ", surface.w, "x", surface.h, " tile:",
       tileWidth, "x", tileHeight]
  spritesheets[index] = surface
  spritesheets[index].tw = tileWidth
  spritesheets[index].th = tileHeight
  spritesheets[index].filename = filename
  if shouldReplace:
    setSpritesheet(index)
  )
```

Not sure if it's needed in other places.