### PR TITLE
Update Nim version on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           #- windows-latest
           #- macOS-latest
         nim_version:
-          - '1.2.0'
+          - '1.4.0'
           - 'stable'
     needs: before
     steps:


### PR DESCRIPTION
CI was failed. ([Log](https://github.com/ftsf/nico/runs/1306130750#step:7:10))
Because `nico.nimble` must need `nim >= 1.4.0`. ([nico.nimble](https://github.com/ftsf/nico/blob/master/nico.nimble#L10))

So upgrade nim version.