### PR TITLE
Remove SDL2 keyListener override that breaks console listener. fixes 47

### DIFF
--- a/nico/backends/sdl2.nim
+++ b/nico/backends/sdl2.nim
@@ -138,8 +138,6 @@ else:
 
 var linearFilter = false
 
-var keyListeners = newSeq[KeyListener]()
-
 var audioDeviceId: AudioDeviceID
 var audioInDeviceId: AudioDeviceID
 var audioInSample*: float32


### PR DESCRIPTION
`keyListeners` is also declared in `backends/common.nim`, overriding this in `sdl2.nim` breaks the console ( ~ ) key listener.
This can be tested by running `vertex.nim` from examples and pressing the tilde ( ~ ) key to launch the debug the console (nothing will happen before this fix).