### PR TITLE
Add loadPaletteFromHexString

### DIFF
--- a/nico.nim
+++ b/nico.nim
@@ -161,6 +161,7 @@ proc glyphWidth*(c: char, scale: Pint = 1): Pint
 proc setColor*(colId: ColorId)
 proc getColor*(): ColorId
 proc loadPaletteFromGPL*(filename: string): Palette
+proc loadPaletteFromHexString*(s: string): Palette
 proc loadPaletteFromImage*(filename: string): Palette
 proc loadPalettePico8*(): Palette
 proc loadPaletteCGA*(mode: range[0..2] = 0, highIntensity: bool = true): Palette
@@ -468,6 +469,17 @@ proc loadPaletteFromImage*(filename: string): Palette =
   while not loaded:
     # force sync
     discard
+  return palette
+
+proc loadPaletteFromHexString*(s: string): Palette =
+  var palette: Palette
+  for i in 0..<s.len/6:
+    let strI = i*6
+    let r = strutils.fromHex[uint8](s[strI..<strI+2])
+    let g = strutils.fromHex[uint8](s[strI+2..<strI+4])
+    let b = strutils.fromHex[uint8](s[strI+4..<strI+6])
+    palette.data[i] = RGB(r, g, b)
+    palette.size += 1
   return palette
 
 proc loadPaletteFromGPL*(filename: string): Palette =

--- a/tests/palette.nim
+++ b/tests/palette.nim
@@ -22,6 +22,12 @@ suite "palette":
     check(palSize() == 256)
     check(pgetRGB(0,0) == (0'u8, 127'u8, 127'u8))
 
+  test "loadPaletteFromHexString":
+    # dawnbringer 16 palette
+    setPalette(loadPaletteFromHexString("140c1c44243430346d4e4a4e854c30346524d04648757161597dced27d2c8595a16daa2cd2aa996dc2cadad45edeeed6"))
+    check(palSize() == 16)
+    check(pgetRGB(0,0) == (0x14'u8, 0x0C'u8, 0x1C'u8))
+
   test "loadPaletteFromImage":
     setPalette(loadPaletteFromImage("palette.png"))
     check(palSize() == 32)


### PR DESCRIPTION
Not sure if you're interested in this procedure, it may be too specific

This procedure loads a palette from a hex string, as used by TIC-80 (see https://github.com/nesbox/TIC-80/wiki/palette and this online palette editing tool: https://aaronsnoswell.github.io/blog/tic-80-color-palette-tool)

It is very convenient because it does not require loading external files, you define your palette in a single string.