### PR TITLE
Auto clean up SDL2 zip in windows deps task, use tar

### DIFF
--- a/exampleApp/exampleApp.nimble
+++ b/exampleApp/exampleApp.nimble
@@ -36,8 +36,15 @@ task debug, "Builds debug exampleApp for current platform":
 
 task deps, "Downloads dependencies":
  if defined(windows):
-  exec "curl https://www.libsdl.org/release/SDL2-2.0.18-win32-x64.zip -o SDL2_x64.zip"
-  exec "unzip SDL2_x64.zip"
+  if not fileExists("SDL2.dll"):
+   if not fileExists("SDL2_x64.zip"):
+    exec "curl https://www.libsdl.org/release/SDL2-2.0.20-win32-x64.zip -o SDL2_x64.zip"
+   if findExe("tar") != "":
+    exec "tar -xf SDL2_x64.zip SDL2.dll"
+   else:
+    exec "unzip SDL2_x64.zip SDL2.dll"
+  if fileExists("SDL2_x64.zip"):
+   rmFile("SDL2_x64.zip")
  elif defined(macosx) and findExe("brew") != "":
   exec "brew list sdl2 || brew install sdl2"
  else:


### PR DESCRIPTION
Use tar to extract SDL2 zip if available, else use unzip
Also update download link to use SDL 2.0.20

On windows 10 tar is available: https://superuser.com/a/1473255/197238
I don't know about unzip however, I guess it doesn't come with windows but may be installed via unix tools.