### PR TITLE
Optimization for DitherNone

### DIFF
--- a/nico.nim
+++ b/nico.nim
@@ -736,12 +736,11 @@ proc ditherADitherXor*(v: float32, a = 149,b = 1234, c = 511) =
   gDitherADitherC = c
 
 proc ditherPass(x,y: int): bool {.inline.} =
+  if gDitherMode == DitherNone:
+    return true
   let x = floorMod(x + gDitherOffsetX, screenWidth)
   let y = floorMod(y + gDitherOffsetY, screenHeight)
-
   case gDitherMode:
-  of DitherNone:
-    return true
   of Dither4x4:
     let x4 = (x mod 4).uint16
     let y4 = (y mod 4).uint16

--- a/nico.nim
+++ b/nico.nim
@@ -741,7 +741,7 @@ proc ditherPass(x,y: int): bool {.inline.} =
     
   let x = floorMod(x + gDitherOffsetX, screenWidth)
   let y = floorMod(y + gDitherOffsetY, screenHeight)
-  
+
   case gDitherMode:
   of DitherNone:
     return true

--- a/nico.nim
+++ b/nico.nim
@@ -738,9 +738,13 @@ proc ditherADitherXor*(v: float32, a = 149,b = 1234, c = 511) =
 proc ditherPass(x,y: int): bool {.inline.} =
   if gDitherMode == DitherNone:
     return true
+    
   let x = floorMod(x + gDitherOffsetX, screenWidth)
   let y = floorMod(y + gDitherOffsetY, screenHeight)
+  
   case gDitherMode:
+  of DitherNone:
+    return true
   of Dither4x4:
     let x4 = (x mod 4).uint16
     let y4 = (y mod 4).uint16


### PR DESCRIPTION
Hi, thanks for creating Nico. I like it a lot.

When using a bigger window size, say 800x600, I noticed quite high CPU comsumption, even when gameDraw() just contains cls().

The cause is that in the very fundamental psetRaw() the functions ditherPass() and stencilTest() are not as cheap as desirable.

Even when not using dithering, the floorMod() calls are performed. This change seeds up drawing a lot, in case dithering is not used.