### PR TITLE
Fix CPU usage when using vsync

### DIFF
--- a/nico/backends/sdl2.nim
+++ b/nico/backends/sdl2.nim
@@ -1876,15 +1876,18 @@ proc run*() =
       if configInitialised:
         step()
 
-      if not vsyncEnabled:
-        # calculate how long we should sleep for to reduce cpu usage, if we have vsync this will do it for us
-        let frameEndTime = getPerformanceCounter()
-        let frameTime = ((frameEndTime - frameStartTime)*1000).float / getPerformanceFrequency().float
-        let targetFrameTime = 1000.0 / frameRate.float
-        let sleepTime = targetFrameTime - frameTime
-        #echo "frame time: ", frameTime, " target: ", targetFrameTime, " sleep time: ", sleepTime
-        if sleepTime > 0f:
+      # calculate how long we should sleep for to reduce cpu usage
+      let frameEndTime = getPerformanceCounter()
+      let frameTime = ((frameEndTime - frameStartTime)*1000).float / getPerformanceFrequency().float
+      let targetFrameTime = 1000.0 / frameRate.float
+      let sleepTime = targetFrameTime - frameTime
+      # echo "frame time: ", frameTime, " target: ", targetFrameTime, " sleep time: ", sleepTime
+      if sleepTime >= 1.0:
+        if vsyncEnabled:
+          delay(1) # if we have vsync this will wait for us, but delay(1) is necessary to keep CPU usage down
+        else:
           delay(sleepTime.uint32)
+
     sdl.quit()
 
 when defined(emscripten):


### PR DESCRIPTION
I noticed that the CPU usage increases over time when using `setVSync(true)`, which is the default. This happens even for a simple example like `lines.nim`.

When using `setVSync(false)`, this does not happen, but of course this has the drawback of tearing or not smooth screen updates.

The main difference when using `setVSync(false)` is in `proc run*()` where waiting is done manually using `delay()`. However, it seems that when solely relying on vsync, CPU usage seems to increase over time.

As a solution this pull request adds a delay(1) even for the vsync case, if `sleepTime` is not smaller than 1.0 ms. This fixes the reported CPU usage problem.