### PR TITLE
Add docs task and workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,24 @@
+name: Generate docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  gen:
+    name: Generate and deploy docs
+    runs-on: ubuntu-latest  
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: iffy/install-nim@v4.1.1
+      - name: Generate
+        run: |
+          nimble install -d -y
+          nimble docs
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/nico.nimble
+++ b/nico.nimble
@@ -31,6 +31,10 @@ task test, "run tests":
   for file in tests:
     exec &"nim c -p:. -r {file}"
 
+task docs, "Generate documentation":
+  exec "nim doc -p:. --git.url:https://github.com/ftsf/nico --git.commit:main --project --outdir:docs nico.nim"
+  exec "echo \"<meta http-equiv=\\\"Refresh\\\" content=\\\"0; url='nico.html'\\\" />\" >> docs/index.html"
+
 task testemscripten, "compile tests with emscripten":
   # test they compile with emscripten backend, harder to test running
   for file in tests:


### PR DESCRIPTION
Nico is a really cool game framework and I really like though something I sometime miss is up-to-date documentation, `API.md` is great but not all procedures are listed and I have to search through the source code, so I thought it would be nice to generate and host the documentation that `nim doc` generates.
- The `docs` task runs `nim doc ...` and creates an `index.html` file that redirects to `nico.html`.
- The `docs.yml` workflow uses https://github.com/peaceiris/actions-gh-pages to deploy the docs folder to gh-pages.

Thanks for making Nico. :heart: 