### PR TITLE
Fix fontBlit() wrong clipping area check

### DIFF
--- a/nico.nim
+++ b/nico.nim
@@ -1693,8 +1693,6 @@ proc fontBlit(font: Font, srcRect, dstRect: Rect, color: ColorId) =
     for x in 0..<dstRect.w:
       if sx.int < 0 or sy.int < 0 or sx.int > font.w - 1 or sy.int > font.h - 1:
         continue
-      if dx.int < clipMinX or dy.int < clipMinY or dx.int > clipMaxX or dy.int > clipMaxY:
-        continue
       if font.data[sy * font.w + sx] == 1:
         pset(dx,dy,currentColor)
 


### PR DESCRIPTION
The fontBlit() proc checks for the clipping area without applying the camera offset. This causes a bug where although it seems like `fontBlit()` accounts for the camera when drawing (since it calls `pset()` to draw), it will _not_ work as expected when the position of the text is outside clipping bounds, even if that position is technically in bounds when accounting for the camera offset.

Additionally, this check is unnecessary, since `pset()` (which is called by `fontBlit()`) applies the camera offset, and then calls `psetRaw()`, which already checks for the clipping area, therefore, we can simply remove this check in `fontBlit()`, as per my commit.