### PR TITLE
Rotation with 3 shears

### DIFF
--- a/examples/benchmark.nim
+++ b/examples/benchmark.nim
@@ -38,6 +38,7 @@ toDraw[bmSprite] = 1000
 toDraw[bmSpriteIntScaled] = 1000
 toDraw[bmSpriteScaled] = 1000
 toDraw[bmSpriteRot] = 1000
+toDraw[bmSpriteShearRot] = 1000
 toDraw[bmTrifill] = 1000
 toDraw[bmTTrifill] = 1000
 

--- a/examples/benchmark.nim
+++ b/examples/benchmark.nim
@@ -15,6 +15,7 @@ type BenchmarkMode = enum
   bmSpriteIntScaled
   bmSpriteScaled
   bmSpriteRot
+  bmSpriteShearRot
   bmTrifill
   bmTTrifill
 
@@ -160,6 +161,10 @@ proc gameDraw() =
   of bmSpriteRot:
     for i in 0..<toDraw:
       sprRot(16+rnd(8), rnd(screenWidth),rnd(screenHeight), rnd(TAU))
+      count += 1
+  of bmSpriteShearRot:
+    for i in 0..<toDraw:
+      sprShearRot(16+rnd(8), rnd(screenWidth),rnd(screenHeight), rnd(TAU))
       count += 1
   of bmTrifill:
     for i in 0..<toDraw:

--- a/examples/rotation.nim
+++ b/examples/rotation.nim
@@ -4,6 +4,7 @@ import math
 
 var angle = 0f
 var mode = 0
+var rotFn = sprRot
 var pos: Vec2f
 
 proc gameInit() =
@@ -25,6 +26,9 @@ proc gameUpdate(dt: Pfloat) =
     if mode > 2:
       mode = 0
 
+  if keyp(K_RETURN):
+    rotFn = if rotFn == sprRot: sprShearRot else: sprRot
+
 proc gameDraw() =
   cls()
 
@@ -35,11 +39,11 @@ proc gameDraw() =
       i+=1
 
   if mode == 0:
-    sprRot(0, pos.x, pos.y, angle, 1, 1)
+    rotFn(0, pos.x, pos.y, angle, 1, 1)
   elif mode == 1:
-    sprRot(1, pos.x, pos.y, angle, 2, 1)
+    rotFn(1, pos.x, pos.y, angle, 2, 1)
   else:
-    sprRot(3, pos.x, pos.y, angle, 1, 2)
+    rotFn(3, pos.x, pos.y, angle, 1, 2)
 
 # initialization
 nico.init("nico", "test")

--- a/nico.nim
+++ b/nico.nim
@@ -1904,6 +1904,74 @@ proc blitFastRot90(src: Surface, srcRect: Rect, dx, dy: Pint, rotations: int) =
       if not paletteTransparent[srcCol]:
         psetRaw(dx, dy, paletteMapDraw[srcCol])
 
+proc shear(radians: float32, x,y: int32): (int32, int32) {.inline.} =
+  ## rotates x,y around the origin by rad radians using 3 shears
+  var rad = radians
+
+  var newX = x.float32
+  var newY = y.float32
+
+  # if angle is > 90 and 270, 
+  # flip the angle and the x,y (effectivement mirroring the sprite on both axes)
+  if rad > PI/2.0 and rad < PI*1.5:
+    rad = rad + PI
+    newX = -newX
+    newY = -newY
+
+  let tangent = tan(rad/2)
+
+  # shear 1
+  newX = round(newX - newY * tangent)
+  # shear 2
+  newY = round(newX * sin(rad) + newY)
+  # shear 3
+  newX = round(newX - newY * tangent)
+
+  return (newX.int32, newY.int32)
+
+proc blitShearRot(src: Surface, srcRect: Rect, centerX,centerY: Pint, radians: float32) =
+  # original algorithm:
+  # https://gautamnagrawal.medium.com/rotating-image-by-any-angle-shear-transformation-using-only-numpy-d28d16eb5076
+
+  # clamp radians to 0-2*PI
+  var radians = radians mod (2*PI)
+  if radians < 0:
+    radians += 2*PI
+
+  let cosRadians = cos(radians)
+  let sinRadians = sin(radians)
+
+  let width = srcRect.w.float32
+  let height = srcRect.h.float32
+  let newWidth = (round(abs(width * cosRadians) + abs(height * sinRadians)) + 1)
+  let newHeight = (round(abs(height * cosRadians) + abs(width * sinRadians)) + 1)
+
+  let ogCenterX = round((width+1)/2 - 1)
+  let ogCenterY = round((height+1)/2 - 1)
+  let dstCenterX = round((newWidth+1)/2 - 1)
+  let dstCenterY = round((newHeight+1)/2 - 1)
+
+  let offsetX = centerX + (ogCenterX - dstCenterX)
+  let offsetY = centerY + (ogCenterY - dstCenterY)
+
+  for i in 0..<height:
+    for j in 0..<width:
+      let x = width - 1 - j - ogCenterX
+      let y = height - 1 - i - ogCenterY
+
+      var (dx, dy) = shear(radians, x, y)
+
+      dx = dstCenterX - dx + offsetX
+      dy = dstCenterY - dy + offsetY
+
+      # check dest pixel is in bounds
+      if dx < clipMinX or dy < clipMinY or dx > clipMaxX or dy > clipMaxY:
+        continue
+
+      let srcCol = src.data[(srcRect.y+i) * src.w + srcRect.x + j].ColorId
+      if not paletteTransparent[srcCol]:
+        pset(dx, dy, paletteMapDraw[srcCol])
+
 proc blitFastFlip(src: Surface, sx,sy, dx,dy, w,h: Pint, hflip, vflip: bool) =
   # used for tile drawing, no stretch
   let startsx = sx + (if hflip: w - 1 else: 0)
@@ -2499,6 +2567,12 @@ proc sprRot*(spr: Pint, x,y: Pint, radians: float32, w,h: Pint = 1) =
   ## draw a rotated sprite, center will be at x,y and rotated around the center
   let src = getSprRect(spr, w, h)
   blitFastRot(spritesheet, src, x, y, radians)
+
+proc sprShearRot*(spr: Pint, x,y: Pint, radians: float32, w,h: Pint = 1) =
+  ## draw a rotated sprite by shearing, center will be at x,y and rotated around the center
+  ## this is 2.5x slower than sprRot() but more accurate and preserves all pixels
+  let src = getSprRect(spr, w, h)
+  blitShearRot(spritesheet, src, x, y, radians)
 
 proc sprRot90*(spr: Pint, x,y: Pint, rotations: int, w,h: Pint = 1) =
   ## draw a 90 degree rotated sprite from top left, rotations = 1 = 90 degrees clockwise, 2 = 180 degrees, 3 = 90 degrees anti-clockwise

--- a/nico.nim
+++ b/nico.nim
@@ -1911,7 +1911,7 @@ proc shear(radians: float32, x,y: int32): (int32, int32) {.inline.} =
   var newX = x.float32
   var newY = y.float32
 
-  # if angle is > 90 and 270, 
+  # if angle is > 90 and < 270, 
   # flip the angle and the x,y (effectivement mirroring the sprite on both axes)
   if rad > PI/2.0 and rad < PI*1.5:
     rad = rad + PI
@@ -1938,21 +1938,11 @@ proc blitShearRot(src: Surface, srcRect: Rect, centerX,centerY: Pint, radians: f
   if radians < 0:
     radians += 2*PI
 
-  let cosRadians = cos(radians)
-  let sinRadians = sin(radians)
-
   let width = srcRect.w.float32
   let height = srcRect.h.float32
-  let newWidth = (round(abs(width * cosRadians) + abs(height * sinRadians)) + 1)
-  let newHeight = (round(abs(height * cosRadians) + abs(width * sinRadians)) + 1)
 
   let ogCenterX = round((width+1)/2 - 1)
   let ogCenterY = round((height+1)/2 - 1)
-  let dstCenterX = round((newWidth+1)/2 - 1)
-  let dstCenterY = round((newHeight+1)/2 - 1)
-
-  let offsetX = centerX + (ogCenterX - dstCenterX) - width/2
-  let offsetY = centerY + (ogCenterY - dstCenterY) - height/2
 
   for i in 0..<height:
     for j in 0..<width:
@@ -1961,8 +1951,8 @@ proc blitShearRot(src: Surface, srcRect: Rect, centerX,centerY: Pint, radians: f
 
       var (dx, dy) = shear(radians, x, y)
 
-      dx = dstCenterX - dx + offsetX - cameraX
-      dy = dstCenterY - dy + offsetY - cameraY
+      dx = -dx + centerX + ogCenterX - width/2 - cameraX
+      dy = -dy + centerY + ogCenterY - height/2 - cameraY
 
       # check dest pixel is in bounds
       if dx < clipMinX or dy < clipMinY or dx > clipMaxX or dy > clipMaxY:

--- a/nico.nim
+++ b/nico.nim
@@ -1951,8 +1951,8 @@ proc blitShearRot(src: Surface, srcRect: Rect, centerX,centerY: Pint, radians: f
   let dstCenterX = round((newWidth+1)/2 - 1)
   let dstCenterY = round((newHeight+1)/2 - 1)
 
-  let offsetX = centerX + (ogCenterX - dstCenterX)
-  let offsetY = centerY + (ogCenterY - dstCenterY)
+  let offsetX = centerX + (ogCenterX - dstCenterX) - width/2
+  let offsetY = centerY + (ogCenterY - dstCenterY) - height/2
 
   for i in 0..<height:
     for j in 0..<width:
@@ -1961,8 +1961,8 @@ proc blitShearRot(src: Surface, srcRect: Rect, centerX,centerY: Pint, radians: f
 
       var (dx, dy) = shear(radians, x, y)
 
-      dx = dstCenterX - dx + offsetX
-      dy = dstCenterY - dy + offsetY
+      dx = dstCenterX - dx + offsetX - cameraX
+      dy = dstCenterY - dy + offsetY - cameraY
 
       # check dest pixel is in bounds
       if dx < clipMinX or dy < clipMinY or dx > clipMaxX or dy > clipMaxY:
@@ -1970,7 +1970,7 @@ proc blitShearRot(src: Surface, srcRect: Rect, centerX,centerY: Pint, radians: f
 
       let srcCol = src.data[(srcRect.y+i) * src.w + srcRect.x + j].ColorId
       if not paletteTransparent[srcCol]:
-        pset(dx, dy, paletteMapDraw[srcCol])
+        psetRaw(dx, dy, paletteMapDraw[srcCol])
 
 proc blitFastFlip(src: Surface, sx,sy, dx,dy, w,h: Pint, hflip, vflip: bool) =
   # used for tile drawing, no stretch


### PR DESCRIPTION
This is an implementation of the 3-shears rotation algorithm. The idea is succinctly explained [here](https://cohost.org/tomforsyth/post/891823-rotation-with-three), and I based my implementation on this [Medium post](https://gautamnagrawal.medium.com/rotating-image-by-any-angle-shear-transformation-using-only-numpy-d28d16eb5076).

Differences with the fastRot implementation:
- Lossless rotation - all pixels are preserved (i.e. no pixel is added or removed)
- The rotation is stable around the center - there's no "wobbliness" when rotating, it's especially noticeable with the red car in the example
- ~2.5x slower than fastRot

I added the algorithm in the benchmarks list, and you can swap between the 2 functions in examples/rotation.nim