### PR TITLE
Fix `loadPaletteGrayscale()`

### DIFF
--- a/nico.nim
+++ b/nico.nim
@@ -617,7 +617,7 @@ proc loadPalettePico8Extra*(): Palette =
 proc loadPaletteGrayscale*(steps: range[1..256] = 256): Palette =
   ## loads grayscale palette with specified number of steps
   for i in 0..<steps:
-    let v = floor(i.float32 / 255f).int
+    let v = floor((i / steps) * 256.0).int
     result.data[i] = RGB(v,v,v)
   result.size = steps
 


### PR DESCRIPTION
Currently, `loadPaletteGrayscale()` is broken. It returns a palette containing `[(0, 0, 0)x255, (1, 1, 1)]`. If you use any number of steps other the default 256 steps, you don't even get the `(1, 1, 1)`.

There are some small things you might want to change, such as the implicit move from `float32` to `float64` in the division and the fact that `(255, 255, 255)` will never be in the palette unless you use the full 256 steps, but at the very least, let's fix the function please :)