### PR TITLE
fix: compilation issue on i386 and nim 2.0

### DIFF
--- a/nico.nim
+++ b/nico.nim
@@ -2224,7 +2224,7 @@ proc glyph*(c: Rune, x,y: Pint, scale: Pint = 1): Pint =
   if not currentFont.rects.hasKey(c):
     return
   let src: Rect = currentFont.rects[c]
-  let dst: Rect = (x.int, y.int, src.w * scale, src.h * scale)
+  let dst: Rect = (x.int, y.int, (src.w * scale).int, (src.h * scale).int)
   try:
     fontBlit(currentFont, src, dst, currentColor)
   except IndexDefect:


### PR DESCRIPTION
Fix compilation error on Nim Compiler Version 2.0.8 [Linux: i386]:

`Error: type mismatch: got '(int, int, int32, int32)' for '(int(x), int(y), src.w * scale, src.h * scale)' but expected 'Rect = tuple[x: int, y: int, w: int, h: int]'`