### PR TITLE
Implement cbool for emscripten_set_main_loop to reflect recent emsdk change

### DIFF
--- a/nico/backends/sdl2.nim
+++ b/nico/backends/sdl2.nim
@@ -1829,6 +1829,7 @@ proc getRecordSeconds*(): int =
     return 0
 
 when defined(emscripten):
+  type cbool* {.importc: "bool", nodecl.} = uint8
   type em_callback_func* = proc() {.cdecl.}
   {.push importc.}
   proc emscripten_set_main_loop*(f: em_callback_func, fps: cint, simulate_infinite_loop: cbool)

--- a/nico/backends/sdl2.nim
+++ b/nico/backends/sdl2.nim
@@ -1831,7 +1831,7 @@ proc getRecordSeconds*(): int =
 when defined(emscripten):
   type em_callback_func* = proc() {.cdecl.}
   {.push importc.}
-  proc emscripten_set_main_loop*(f: em_callback_func, fps, simulate_infinite_loop: cint)
+  proc emscripten_set_main_loop*(f: em_callback_func, fps: cint, simulate_infinite_loop: cbool)
   proc emscripten_cancel_main_loop*()
   {.pop.}
 


### PR DESCRIPTION
This is related to and resolves issue #129 for me. 

Emsdk recently changed the type signature for emscripten_set_main_loop specifically changing the argument from int to bool. There exists an issue when linking emscripten in regards to the definition of a ctype for bool. Nim language has proper support for the bool (boolean) C99 type however the function definitions use custom defined types to match the fact that WASM thunks everything to int32? Either way by adding a cbool type which corresponds to the "bool" declared in emsdk function definition the linking now doesnt fail. 

[emsdk breaking change](https://github.com/emscripten-core/emscripten/commit/3dfabe6ded598cd23c64968ae213ea98a0ad180f)

I spoke to the nimlang developers in matrix chat that pointed me to the proper definition for bool internal to nim language so it lead me to believe that its related to nico. though adding the same cbool declaration to nim/system/ctypes.nim also alleviated the issue I feel a bit out of my depth here in the sense that I cant fully articulate where the problem is. 

Also spoke to the emsdk developer who made the change. Investigating how to write tests for this or where to look.